### PR TITLE
Feat/#9

### DIFF
--- a/src/main/java/com/progmong/api/explore/controller/ExploreController.java
+++ b/src/main/java/com/progmong/api/explore/controller/ExploreController.java
@@ -1,6 +1,7 @@
 package com.progmong.api.explore.controller;
 
 import com.progmong.api.explore.dto.ExploreStartRequestDto;
+import com.progmong.api.explore.dto.ProblemRecordListQueryDto;
 import com.progmong.api.explore.dto.RecommendProblemListResponseDto;
 import com.progmong.api.explore.service.ExploreService;
 import com.progmong.common.response.ApiResponse;
@@ -65,4 +66,24 @@ public class ExploreController {
         RecommendProblemListResponseDto recommendProblemListDto = exploreService.currentExplore(userId);
         return ApiResponse.success(SuccessStatus.EXPLORE_START,recommendProblemListDto);
     }
+
+    @GetMapping("/records/all")
+    public ApiResponse<ProblemRecordListQueryDto> getAllRecords(Long userId) {
+        return ApiResponse.success(SuccessStatus.GET_ALL_RECORD,exploreService.getAllProblemRecords(userId)).getBody();
+    }
+
+    @GetMapping("/records")
+    public ApiResponse<ProblemRecordListQueryDto> getRecentRecords(
+            Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        return ApiResponse.success(SuccessStatus.GET_PAGED_RECORD,exploreService.getRecentProblemRecords(userId, page, size)).getBody();
+    }
+
+    @GetMapping("/records/count")
+    public ApiResponse<Long> getTotalRecordCount(Long userId) {
+        return ApiResponse.success(SuccessStatus.GET_ALL_RECORD_COUNT,exploreService.getProblemRecordCount(userId)).getBody();
+    }
+
 }

--- a/src/main/java/com/progmong/api/explore/dto/ProblemRecordListQueryDto.java
+++ b/src/main/java/com/progmong/api/explore/dto/ProblemRecordListQueryDto.java
@@ -1,0 +1,18 @@
+package com.progmong.api.explore.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProblemRecordListQueryDto(
+        List<ProblemRecordQueryDto> records,
+        long totalCount
+) {
+    public static ProblemRecordListQueryDto of(List<ProblemRecordQueryDto> records, long totalCount) {
+        return ProblemRecordListQueryDto.builder()
+                .records(records)
+                .totalCount(totalCount)
+                .build();
+    }
+}

--- a/src/main/java/com/progmong/api/explore/dto/ProblemRecordQueryDto.java
+++ b/src/main/java/com/progmong/api/explore/dto/ProblemRecordQueryDto.java
@@ -1,0 +1,26 @@
+package com.progmong.api.explore.dto;
+
+import com.progmong.api.explore.entity.ProblemRecord;
+import com.progmong.api.explore.entity.Result;
+import lombok.Builder;
+
+@Builder
+public record ProblemRecordQueryDto(
+        Long recordId,
+        Long problemId,
+        String title,
+        int level,
+        String mainTag,
+        Result result
+) {
+    public static ProblemRecordQueryDto fromEntity(ProblemRecord entity) {
+        return ProblemRecordQueryDto.builder()
+                .recordId(entity.getId())
+                .problemId(entity.getProblem().getId())
+                .title(entity.getProblem().getTitle())
+                .level(entity.getProblem().getLevel())
+                .mainTag(entity.getProblem().getMainTag())
+                .result(entity.getResult())
+                .build();
+    }
+}

--- a/src/main/java/com/progmong/api/explore/repository/ProblemRecordRepository.java
+++ b/src/main/java/com/progmong/api/explore/repository/ProblemRecordRepository.java
@@ -1,0 +1,14 @@
+package com.progmong.api.explore.repository;
+
+import com.progmong.api.explore.entity.ProblemRecord;
+import com.progmong.api.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRecordRepository extends JpaRepository<ProblemRecord, Long> {
+
+    Page<ProblemRecord> findByUser(User user, Pageable pageable);
+
+    long countByUser(User user);
+}

--- a/src/main/java/com/progmong/api/explore/service/ExploreService.java
+++ b/src/main/java/com/progmong/api/explore/service/ExploreService.java
@@ -169,4 +169,14 @@ public class ExploreService {
         // 5. 총 개수 포함 응답 반환
         return ProblemRecordListQueryDto.of(recordDtos, recordsPage.getTotalElements());
     }
+
+    @Transactional(readOnly = true)
+    public long getProblemRecordCount(Long userId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+
+        // 2. 해당 사용자의 총 사냥 기록 수 반환
+        return problemRecordRepository.countByUser(user);
+    }
 }

--- a/src/main/java/com/progmong/api/pet/service/UserPetService.java
+++ b/src/main/java/com/progmong/api/pet/service/UserPetService.java
@@ -38,7 +38,6 @@ public class UserPetService {
                 .user(user)
                 .pet(pet)
                 .level(1)
-                .exp(0)
                 .status(PetStatus.휴식)
                 .message(null)
                 .isProud(false)

--- a/src/main/java/com/progmong/common/response/SuccessStatus.java
+++ b/src/main/java/com/progmong/common/response/SuccessStatus.java
@@ -19,7 +19,10 @@ public enum SuccessStatus {
     PET_REGISTERED(HttpStatus.CREATED, "펫 등록이 완료되었습니다."),
     POST_DELETED(HttpStatus.OK, "게시글이 삭제되었습니다."),
 
-    EXPLORE_START(HttpStatus.OK, "탐험 시작 성공");
+    EXPLORE_START(HttpStatus.OK, "탐험 시작 성공"),
+    GET_ALL_RECORD(HttpStatus.OK, "모든 사냥 기록 조회에 성공했습니다."),
+    GET_PAGED_RECORD(HttpStatus.OK, "페이지네이션이 적용된 사냥 기록 조회에 성공했습니다."),
+    GET_ALL_RECORD_COUNT(HttpStatus.OK, "모든 사냔 기록의 갯수 조회를 성공했습니다." ),;
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #9 

## 📝 Summary

- 사용자 사냥(도전) 기록을 조회하기 위한 API 3종 구현
  - 전체 기록 조회
  - 최근 기록 페이징 조회
  - 전체 기록 수 조회
- `ProblemRecordQueryDto`, `ProblemRecordListQueryDto` 응답용 DTO 설계
- `ExploreService`에 기능 추가 및 `ExploreController`에 엔드포인트 구현
- 공통 응답 포맷(`ApiResponse<T>`) 적용


## 🙏 Question & PR point

- `ProblemRecordRepository` 생성 (페이징 + count)
- `ExploreService`
  - `getAllProblemRecords(userId)`
  - `getRecentProblemRecords(userId, page, size)`
  - `getProblemRecordCount(userId)`
- `ExploreController`
  - `GET /api/v1/explore/records/all`
  - `GET /api/v1/explore/records?page=0&size=5`
  - `GET /api/v1/explore/records/count`
- 조회 결과 없는 경우에도 200 OK + 빈 리스트 반환
