### PR TITLE
feat(explore): 탐험 성공 기능 구현 (#6)

### DIFF
--- a/src/main/java/com/progmong/api/explore/controller/ExploreController.java
+++ b/src/main/java/com/progmong/api/explore/controller/ExploreController.java
@@ -65,4 +65,20 @@ public class ExploreController {
         RecommendProblemListResponseDto recommendProblemListDto = exploreService.currentExplore(userId);
         return ApiResponse.success(SuccessStatus.EXPLORE_START,recommendProblemListDto);
     }
+
+    @PostMapping("/success")
+    @Operation(
+            summary = "탐험 문제 풀이 성공",
+            description = "현재 전투 중인 문제를 성공 처리하고 경험치를 반영합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탐험 문제 풀이 성공 완료")
+    })
+    public ResponseEntity<ApiResponse<RecommendProblemListResponseDto>> successExplore(
+            @RequestParam Long userId
+    ) {
+        RecommendProblemListResponseDto result = exploreService.successExplore(userId);
+        return ApiResponse.success(SuccessStatus.EXPLORE_PROBLEM_SUCCESS, result);
+    }
+
 }

--- a/src/main/java/com/progmong/api/explore/dto/RecommendProblemListResponseDto.java
+++ b/src/main/java/com/progmong/api/explore/dto/RecommendProblemListResponseDto.java
@@ -9,4 +9,6 @@ import java.util.List;
 @AllArgsConstructor
 public class RecommendProblemListResponseDto {
     private List<RecommendProblemResponseDto> recommendProblems;
+    private boolean isFinish;
+    private Integer totalExp; // 종료 시만 값 존재, 아니면 null
 }

--- a/src/main/java/com/progmong/api/explore/entity/ProblemRecord.java
+++ b/src/main/java/com/progmong/api/explore/entity/ProblemRecord.java
@@ -1,5 +1,6 @@
 package com.progmong.api.explore.entity;
 
+import com.progmong.api.pet.entity.PetStatus;
 import com.progmong.api.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -29,4 +30,8 @@ public class ProblemRecord {
 
     @Enumerated(EnumType.STRING)
     private Result result;
+
+    public void updateResult(Result result) {
+        this.result = result;
+    }
 }

--- a/src/main/java/com/progmong/api/explore/repository/ProblemRecordRepository.java
+++ b/src/main/java/com/progmong/api/explore/repository/ProblemRecordRepository.java
@@ -1,0 +1,10 @@
+package com.progmong.api.explore.repository;
+
+import com.progmong.api.explore.entity.ProblemRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProblemRecordRepository extends JpaRepository<ProblemRecord,Long> {
+    Optional<ProblemRecord> findByUserIdAndProblemId(Long userId, Long problemId);
+}

--- a/src/main/java/com/progmong/api/explore/repository/RecommendProblemRepository.java
+++ b/src/main/java/com/progmong/api/explore/repository/RecommendProblemRepository.java
@@ -11,4 +11,6 @@ public interface RecommendProblemRepository extends JpaRepository<RecommendProbl
     Optional<RecommendProblem> findByUserIdAndStatus(Long userId, RecommendStatus recommendStatus);
     Optional<RecommendProblem> findByUserIdAndSequence(Long userId,int sequence);
     List<RecommendProblem> findAllByUserIdOrderBySequence(Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/progmong/api/explore/repository/SolvedProblemRepository.java
+++ b/src/main/java/com/progmong/api/explore/repository/SolvedProblemRepository.java
@@ -4,4 +4,5 @@ import com.progmong.api.explore.entity.SolvedProblem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SolvedProblemRepository extends JpaRepository<SolvedProblem,Long> {
+    boolean existsByUserIdAndProblemId(Long userId, Long problemId);
 }

--- a/src/main/java/com/progmong/api/pet/entity/UserPet.java
+++ b/src/main/java/com/progmong/api/pet/entity/UserPet.java
@@ -36,7 +36,7 @@ public class UserPet extends BaseTimeEntity {
     @ColumnDefault("0")
     private int currentExp;
 
-    @ColumnDefault("500")
+    @ColumnDefault("50")
     private int maxExp;
 
     @Enumerated(EnumType.STRING)
@@ -54,5 +54,19 @@ public class UserPet extends BaseTimeEntity {
 
     public void updateStatus(PetStatus status) {
         this.status = status;
+    }
+
+    public void addExp(int exp) {
+        this.currentExp += exp;
+
+        while (this.currentExp >= this.maxExp) {
+            this.currentExp -= this.maxExp;
+            this.level++;
+            this.maxExp += 200;
+
+            if (this.level == 6 || this.level == 11 || this.level == 16) {
+                this.evolutionStage++;
+            }
+        }
     }
 }

--- a/src/main/java/com/progmong/common/response/SuccessStatus.java
+++ b/src/main/java/com/progmong/common/response/SuccessStatus.java
@@ -19,7 +19,9 @@ public enum SuccessStatus {
     PET_REGISTERED(HttpStatus.CREATED, "펫 등록이 완료되었습니다."),
     POST_DELETED(HttpStatus.OK, "게시글이 삭제되었습니다."),
 
-    EXPLORE_START(HttpStatus.OK, "탐험 시작 성공");
+    EXPLORE_START(HttpStatus.OK, "탐험 시작 성공"),
+    EXPLORE_GET(HttpStatus.OK,"탐험 조회 성공"),
+    EXPLORE_PROBLEM_SUCCESS(HttpStatus.OK, "탐험 문제 풀이 성공");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #6 

## 📝 Summary
- 문제 성공 시 상태를 성공으로 변경하고, 다음 문제의 상태를 전투로 변경합니다.
- 경험치는 문제 경험치에 따라 펫의 현재 경험치에 누적됩니다.