### PR TITLE
Feat/#12

### DIFF
--- a/src/main/java/com/progmong/api/pet/service/UserPetService.java
+++ b/src/main/java/com/progmong/api/pet/service/UserPetService.java
@@ -13,6 +13,7 @@ import com.progmong.common.exception.NotFoundException;
 import com.progmong.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -23,7 +24,7 @@ public class UserPetService {
     private final UserRepository userRepository;
     private final PetRepository petRepository;
 
-    //@Transactional //여러 DB 작업이 엮일 경우
+    @Transactional //여러 DB 작업이 엮일 경우
     public void registerPet(PetRegisterRequestDto request){
         if(userPetRepository.findByUserId(request.getUserId()).isPresent()){
             throw new BadRequestException(ErrorStatus.ALREADY_REGISTERED_PET.getMessage());

--- a/src/main/java/com/progmong/api/tag/controller/InterestTagController.java
+++ b/src/main/java/com/progmong/api/tag/controller/InterestTagController.java
@@ -1,0 +1,43 @@
+package com.progmong.api.tag.controller;
+
+import com.progmong.api.tag.dto.InterestTagResponseDto;
+import com.progmong.api.tag.dto.InterestTagUpdateRequestDto;
+import com.progmong.api.tag.service.InterestTagService;
+import com.progmong.common.response.ApiResponse;
+import com.progmong.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "InterestTag", description = "관심 태그 관련 API입니다.")
+@RestController
+@RequestMapping("/api/v1/tag")
+@RequiredArgsConstructor
+public class InterestTagController {
+
+    private final InterestTagService interestTagService;
+
+    @PutMapping
+    @Operation(summary = "관심 태그 수정", description = "사용자가 선택한 태그 목록을 기반으로 관심 태그를 갱신합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관심 태그 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 태그가 존재하지 않음"),
+    })
+    public ResponseEntity<ApiResponse<Void>> updateInterestTags(@RequestBody InterestTagUpdateRequestDto request) {
+        interestTagService.updateInterestTags(request.getUserId(), request.getTagIds());
+        return ApiResponse.success_only(SuccessStatus.INTEREST_TAG_UPDATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<InterestTagResponseDto>>> getUserInterestTags(
+            @RequestParam Long userId  // AuthenticationPrincipal 이후 교체 예정
+    ) {
+        List<InterestTagResponseDto> tags = interestTagService.getUserInterestTags(userId);
+        return ApiResponse.success(SuccessStatus.INTEREST_TAG_FOUND, tags);
+    }
+}

--- a/src/main/java/com/progmong/api/tag/dto/InterestTagResponseDto.java
+++ b/src/main/java/com/progmong/api/tag/dto/InterestTagResponseDto.java
@@ -1,0 +1,11 @@
+package com.progmong.api.tag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InterestTagResponseDto {       // interest_tag의 get에 사용
+    private Long id;    // userId AuthenticationPrincipal 이후 교체 예정
+    private String name;
+}

--- a/src/main/java/com/progmong/api/tag/dto/InterestTagUpdateRequestDto.java
+++ b/src/main/java/com/progmong/api/tag/dto/InterestTagUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.progmong.api.tag.dto;
+
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class InterestTagUpdateRequestDto {
+    private Long userId;        //jwt 구현 후 삭제
+    private List<Long> tagIds;  // 최종적으로 선택된 tagId 목록
+}

--- a/src/main/java/com/progmong/api/tag/repository/InterestTagRepository.java
+++ b/src/main/java/com/progmong/api/tag/repository/InterestTagRepository.java
@@ -1,0 +1,14 @@
+package com.progmong.api.tag.repository;
+
+
+import com.progmong.api.tag.entity.InterestTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterestTagRepository  extends JpaRepository<InterestTag, Long> {
+    List<InterestTag> findByUserId(Long userId);
+    void deleteByUserIdAndTagIdIn(Long userId, List<Long> tagIds);
+    void deleteByUserId(Long userId);
+    boolean existsByUserIdAndTagId(Long userId, Long tagId);
+}

--- a/src/main/java/com/progmong/api/tag/repository/TagRepository.java
+++ b/src/main/java/com/progmong/api/tag/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.progmong.api.tag.repository;
+
+import com.progmong.api.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/progmong/api/tag/service/InterestTagService.java
+++ b/src/main/java/com/progmong/api/tag/service/InterestTagService.java
@@ -1,0 +1,84 @@
+package com.progmong.api.tag.service;
+
+
+import com.progmong.api.tag.dto.InterestTagResponseDto;
+import com.progmong.api.tag.entity.InterestTag;
+import com.progmong.api.tag.entity.Tag;
+import com.progmong.api.tag.repository.InterestTagRepository;
+import com.progmong.api.tag.repository.TagRepository;
+import com.progmong.api.user.entity.User;
+import com.progmong.api.user.repository.UserRepository;
+import com.progmong.common.exception.NotFoundException;
+import com.progmong.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InterestTagService {
+
+    private final InterestTagRepository interestTagRepository;
+    private final TagRepository tagRepository;
+    private final UserRepository userRepository;
+
+    // 관심 태그 갱신 (PUT)
+    @Transactional
+    public void updateInterestTags(Long userId, List<Long> updatedTagIds) {
+        // 1. 현재 사용자의 관심 태그 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+
+        List<InterestTag> currentInterestTags = interestTagRepository.findByUserId(userId);
+        Set<Long> currentTagIds = currentInterestTags.stream()
+                .map(interestTag -> interestTag.getTag().getId())
+                .collect(Collectors.toSet());
+
+        Set<Long> updatedTagIdSet = new HashSet<>(updatedTagIds);
+
+        // 2. 삭제할 태그 ID: 현재는 있는데 선택 안된 태그
+        List<Long> tagsToDelete = currentTagIds.stream()
+                .filter(tagId -> !updatedTagIdSet.contains(tagId))
+                .toList();
+
+        if (!tagsToDelete.isEmpty()) {
+            interestTagRepository.deleteByUserIdAndTagIdIn(userId, tagsToDelete);
+        }
+
+        // 3. 추가할 태그 ID: 새롭게 선택된 태그
+        List<Long> tagsToAdd = updatedTagIdSet.stream()
+                .filter(tagId -> !currentTagIds.contains(tagId))
+                .toList();
+
+        for (Long tagId : tagsToAdd) {
+            Tag tag = tagRepository.findById(tagId)
+                    .orElseThrow(() -> new RuntimeException("Tag not found"));
+
+            InterestTag newInterestTag = InterestTag.builder()
+                    .user(user)
+                    .tag(tag)
+                    .build();
+
+            interestTagRepository.save(newInterestTag);
+        }
+    }
+
+    // ✅ 관심 태그 조회 (GET)
+    @Transactional(readOnly = true)
+    public List<InterestTagResponseDto> getUserInterestTags(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+
+        return user.getInterestTags().stream()
+                .map(interestTag -> {
+                    Tag tag = interestTag.getTag();
+                    return new InterestTagResponseDto(tag.getId(), tag.getName());
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/progmong/common/response/SuccessStatus.java
+++ b/src/main/java/com/progmong/common/response/SuccessStatus.java
@@ -18,7 +18,8 @@ public enum SuccessStatus {
     PET_STATUS_UPDATED(HttpStatus.OK, "펫 상태가 변경되었습니다."),
     PET_REGISTERED(HttpStatus.CREATED, "펫 등록이 완료되었습니다."),
     POST_DELETED(HttpStatus.OK, "게시글이 삭제되었습니다."),
-
+    INTEREST_TAG_FOUND(HttpStatus.OK, "관심 태그 조회 성공"),
+    INTEREST_TAG_UPDATED(HttpStatus.OK,"관심 태그가 성공적으로 수정되었습니다."),
     EXPLORE_START(HttpStatus.OK, "탐험 시작 성공"),
     GET_ALL_RECORD(HttpStatus.OK, "모든 사냥 기록 조회에 성공했습니다."),
     GET_PAGED_RECORD(HttpStatus.OK, "페이지네이션이 적용된 사냥 기록 조회에 성공했습니다."),


### PR DESCRIPTION
## 📣 Related Issue

- close #12 

## 📝 Summary

- 사용자 관심 태그 조회(GET) 기능 구현
- 사용자 관심 태그 전체 갱신(PUT) 기능 구현
- 기존 관심 태그와 비교하여, 새로 선택된 태그는 추가하고, 제외된 태그는 삭제하는 방식으로 동기화
- Swagger 어노테이션 및 응답 DTO 작성

## 🙏 Question & PR point

- 현재 userId는 하드코딩 방식으로 처리되어 있으며, JWT 적용 후 @AuthenticationPrincipal 방식으로 변경 예정입니다.

- 프론트(마이페이지, 탐험 전)에서 초기 관심 태그 상태를 설정하기 위해, 사용자 관심 태그 조회(GET) 기능을 추가 구현했습니다.
  - 프론트에서 초기 관심 태그의 토글 상태를 설정하려면 현재 DB에 저장된 관심 태그 값을 먼저 조회해야 할 필요가 생겼습니다.
  - 따라서 사용자의 기존 관심 태그 목록을 불러오는 GET /api/v1/tag API를 추가 구현했습니다.
  - 이 API를 통해 프론트는 전체 태그 중 어떤 태그가 사용자의 관심 태그인지 확인하고, 해당 정보를 태그 선택 토글 버튼에 반영할 수 있습니다.

- 관심 태그 수정 시 DELETE, POST로 나누지 않고 PUT으로 통합 처리한 이유는 아래와 같습니다:
  - 우리는 태그를 수정할 때 '추가냐 삭제냐'를 나눠서 보내는 게 아니라, 사용자가 지금 선택한 tag 리스트 자체가 최종 상태임.
  - 따라서 클라이언트는 변경 내역이 아닌 "최종 상태"를 서버에 보내는 것이며, 이는 REST에서 PUT 방식의 의미와 일치함.
  - 내부적으로 어떤 tag는 삭제되고, 어떤 tag는 새로 추가되더라도, 클라이언트 입장에서는 관심 태그 전체를 갱신(교체)했다고 보면 됩니다.
