### PR TITLE
[REFAC] JWT 기반 사용자 인증으로 관심 태그/펫 등록 기능 수정

### DIFF
--- a/src/main/java/com/progmong/api/pet/controller/UserPetController.java
+++ b/src/main/java/com/progmong/api/pet/controller/UserPetController.java
@@ -2,13 +2,16 @@ package com.progmong.api.pet.controller;
 
 import com.progmong.api.pet.dto.PetRegisterRequestDto;
 import com.progmong.api.pet.service.UserPetService;
+import com.progmong.common.config.security.SecurityUser;
 import com.progmong.common.response.ApiResponse;
 import com.progmong.common.response.SuccessStatus;
+import com.sun.security.auth.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +32,13 @@ public class UserPetController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 유저인 경우 또는 존재하지 않는 펫을 선택한 경우"),
     })
 
-    public ResponseEntity<ApiResponse<Void>> registerPet(@RequestBody PetRegisterRequestDto request) {
-        userPetService.registerPet(request);
+    public ResponseEntity<ApiResponse<Void>> registerPet(
+            @RequestBody PetRegisterRequestDto request,
+            @AuthenticationPrincipal SecurityUser user) {
+
+        Long userId = user.getId(); // Spring Security 기반
+        //Long userId = Long.parseLong(principal.); // username에 ID 저장한 경우
+        userPetService.registerPet(request, userId);
         return ApiResponse.success_only(SuccessStatus.PET_REGISTERED);
     }
 }

--- a/src/main/java/com/progmong/api/pet/dto/PetRegisterRequestDto.java
+++ b/src/main/java/com/progmong/api/pet/dto/PetRegisterRequestDto.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class PetRegisterRequestDto {
-    private Long userId;
     private Long petId;
     private String nickname;
 }

--- a/src/main/java/com/progmong/api/pet/service/UserPetService.java
+++ b/src/main/java/com/progmong/api/pet/service/UserPetService.java
@@ -25,12 +25,12 @@ public class UserPetService {
     private final PetRepository petRepository;
 
     @Transactional //여러 DB 작업이 엮일 경우
-    public void registerPet(PetRegisterRequestDto request){
-        if(userPetRepository.findByUserId(request.getUserId()).isPresent()){
+    public void registerPet(PetRegisterRequestDto request, Long userId){
+        if(userPetRepository.findByUserId(userId).isPresent()){
             throw new BadRequestException(ErrorStatus.ALREADY_REGISTERED_PET.getMessage());
         }
 
-        User user = userRepository.findById(request.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
         Pet pet = petRepository.findById(request.getPetId())
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.PET_NOT_FOUND.getMessage()));

--- a/src/main/java/com/progmong/api/tag/controller/InterestTagController.java
+++ b/src/main/java/com/progmong/api/tag/controller/InterestTagController.java
@@ -3,6 +3,7 @@ package com.progmong.api.tag.controller;
 import com.progmong.api.tag.dto.InterestTagResponseDto;
 import com.progmong.api.tag.dto.InterestTagUpdateRequestDto;
 import com.progmong.api.tag.service.InterestTagService;
+import com.progmong.common.config.security.SecurityUser;
 import com.progmong.common.response.ApiResponse;
 import com.progmong.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,16 +30,17 @@ public class InterestTagController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관심 태그 수정 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 태그가 존재하지 않음"),
     })
-    public ResponseEntity<ApiResponse<Void>> updateInterestTags(@RequestBody InterestTagUpdateRequestDto request) {
-        interestTagService.updateInterestTags(request.getUserId(), request.getTagIds());
+    public ResponseEntity<ApiResponse<Void>> updateInterestTags(
+            @RequestBody InterestTagUpdateRequestDto request,
+            @AuthenticationPrincipal SecurityUser user) {
+        interestTagService.updateInterestTags(user.getId(), request.getTagIds());
         return ApiResponse.success_only(SuccessStatus.INTEREST_TAG_UPDATED);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<InterestTagResponseDto>>> getUserInterestTags(
-            @RequestParam Long userId  // AuthenticationPrincipal 이후 교체 예정
-    ) {
-        List<InterestTagResponseDto> tags = interestTagService.getUserInterestTags(userId);
+            @AuthenticationPrincipal SecurityUser user) {
+        List<InterestTagResponseDto> tags = interestTagService.getUserInterestTags(user.getId());
         return ApiResponse.success(SuccessStatus.INTEREST_TAG_FOUND, tags);
     }
 }

--- a/src/main/java/com/progmong/api/tag/dto/InterestTagResponseDto.java
+++ b/src/main/java/com/progmong/api/tag/dto/InterestTagResponseDto.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class InterestTagResponseDto {       // interest_tag의 get에 사용
-    private Long id;    // userId AuthenticationPrincipal 이후 교체 예정
+    private Long id;    // tag id
     private String name;
 }

--- a/src/main/java/com/progmong/api/tag/dto/InterestTagUpdateRequestDto.java
+++ b/src/main/java/com/progmong/api/tag/dto/InterestTagUpdateRequestDto.java
@@ -7,6 +7,5 @@ import java.util.List;
 
 @Getter
 public class InterestTagUpdateRequestDto {
-    private Long userId;        //jwt 구현 후 삭제
     private List<Long> tagIds;  // 최종적으로 선택된 tagId 목록
 }


### PR DESCRIPTION
## 📣 Related Issue
JWT 기반 사용자 인증으로 관심 태그/펫 등록 기능 수정
- close #17 

## 📝 Summary
### 🐾 Pet 등록 기능 리팩토링
- `PetRegisterRequestDto`에서 `userId` 필드 제거
- 인증된 사용자 정보를 통해 `userId`를 컨트롤러에서 별도 전달하도록 구조 변경
- `UserPetService.registerPet()` 시그니처 변경  
  → `registerPet(PetRegisterRequestDto request, Long userId)`
- 기존 DTO 중심 로직을 인증 기반 로직으로 리팩토링

### 🏷️ 관심 태그 API 인증 연동
- Tag관련 Dto에서 userId 연관 필드 제거
- 관심 태그 조회 및 수정 시 `@AuthenticationPrincipal SecurityUser`를 통해 인증된 사용자 ID 획득
- 클라이언트 측 하드코딩된 userId 제거 및 access token 기반 요청 적용 전제


## 🙏 Question & PR point
- 전반적으로 DTO에 `userId`를 명시적으로 받던 설계에서 JWT 인증을 통해 controller에서 처리하는 구조로 바꿨습니다.  
