### PR TITLE
Feat/#26 사용자 펫 정보 불러오기

### DIFF
--- a/src/main/java/com/progmong/api/pet/controller/UserPetController.java
+++ b/src/main/java/com/progmong/api/pet/controller/UserPetController.java
@@ -1,6 +1,7 @@
 package com.progmong.api.pet.controller;
 
 import com.progmong.api.pet.dto.PetRegisterRequestDto;
+import com.progmong.api.pet.dto.UserPetFullDto;
 import com.progmong.api.pet.service.UserPetService;
 import com.progmong.common.config.security.SecurityUser;
 import com.progmong.common.response.ApiResponse;
@@ -12,10 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Pet", description = "펫 관련 API입니다.")
 @RestController
@@ -40,5 +39,18 @@ public class UserPetController {
         //Long userId = Long.parseLong(principal.); // username에 ID 저장한 경우
         userPetService.registerPet(request, userId);
         return ApiResponse.success_only(SuccessStatus.PET_REGISTERED);
+    }
+
+    @GetMapping("/all")
+    @Operation(summary = "내 펫 정보 조회", description = "로그인한 사용자의 펫 전체 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 유저의 펫 정보가 없음")
+    })
+    public ResponseEntity<ApiResponse<UserPetFullDto>> getUserPetFullInfo(
+            @AuthenticationPrincipal SecurityUser user) {
+        Long userId = user.getId();
+        UserPetFullDto dto = userPetService.getUserPetFullInfo(userId);
+        return ApiResponse.success(SuccessStatus.PET_INFO_LOADED, dto);
     }
 }

--- a/src/main/java/com/progmong/api/pet/dto/UserPetFullDto.java
+++ b/src/main/java/com/progmong/api/pet/dto/UserPetFullDto.java
@@ -1,0 +1,42 @@
+package com.progmong.api.pet.dto;
+
+
+import com.progmong.api.pet.entity.Pet;
+import com.progmong.api.pet.entity.PetStatus;
+import com.progmong.api.pet.entity.UserPet;
+import com.progmong.api.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserPetFullDto {
+
+    private Long userPetId;
+    private Long  userId;
+    private Long  petId;
+    private int level;
+    private int currentExp;
+    private int maxExp;
+    private PetStatus status;
+    private String message;
+    private boolean isProud;
+    private String nickname;
+    private int evolutionStage;
+
+    public UserPetFullDto(UserPet userPet) {
+        this.userPetId = userPet.getId();
+        this.userId = userPet.getUser().getId();
+        this.petId = userPet.getPet().getId();
+        this.level = userPet.getLevel();
+        this.currentExp = userPet.getCurrentExp();
+        this.maxExp = userPet.getMaxExp();
+        this.status = userPet.getStatus();
+        this.message = userPet.getMessage();
+        this.isProud = userPet.isProud(); // boolean은 is~ 메서드로 받아야 함
+        this.nickname = userPet.getNickname();
+        this.evolutionStage = userPet.getEvolutionStage();
+    }
+}

--- a/src/main/java/com/progmong/api/pet/service/UserPetService.java
+++ b/src/main/java/com/progmong/api/pet/service/UserPetService.java
@@ -1,6 +1,7 @@
 package com.progmong.api.pet.service;
 
 import com.progmong.api.pet.dto.PetRegisterRequestDto;
+import com.progmong.api.pet.dto.UserPetFullDto;
 import com.progmong.api.pet.entity.Pet;
 import com.progmong.api.pet.entity.PetStatus;
 import com.progmong.api.pet.entity.UserPet;
@@ -47,8 +48,11 @@ public class UserPetService {
                 .build();
 
         userPetRepository.save(userPet);
+    }
 
-
-
+    public UserPetFullDto getUserPetFullInfo(Long userId) {
+        UserPet userPet = userPetRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저의 펫 정보가 없습니다."));
+        return new UserPetFullDto(userPet);
     }
 }

--- a/src/main/java/com/progmong/common/response/SuccessStatus.java
+++ b/src/main/java/com/progmong/common/response/SuccessStatus.java
@@ -21,6 +21,7 @@ public enum SuccessStatus {
     SEND_PASSWORD_RESET_CODE_SUCCESS(HttpStatus.OK,"비밀번호 초기화 코드 전송 성공"),
     SEND_UPDATE_USER_PASSWORD(HttpStatus.OK, "비밀번호 변경 성공"),
     GET_USER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
+    PET_INFO_LOADED(HttpStatus.OK, "사용자 펫 정보 조회 성공"),
 
     PET_STATUS_UPDATED(HttpStatus.OK, "펫 상태가 변경되었습니다."),
     PET_REGISTERED(HttpStatus.CREATED, "펫 등록이 완료되었습니다."),


### PR DESCRIPTION
## 📣 Related Issue
사용자 펫 정보 불러오기
- close #26 

## 📝 Summary

- 사용자의 펫 전체 정보를 가져오는 Dto, controller, service 작성
  - 유저펫의 전체 정보를 가져올 수 있기 때문에 향후 메인페이지와 마이페이지에서 
  - 해당 사용자 펫의 모든 정보를 가져와 status, message, 경험치, 레벨, 닉네임, 자랑하기 여부 등 필요한 것만 추출하여 쓴다.
