### PR TITLE
Feat/#36 리프레시 토큰 추가 및 유저 펫 정보조회 수정

### DIFF
--- a/src/main/java/com/progmong/api/health/HealthCheckController.java
+++ b/src/main/java/com/progmong/api/health/HealthCheckController.java
@@ -12,11 +12,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "HealthCheck", description = "HealthCheck 관련 API 입니다.")
 @RestController
+@RequestMapping("/api/v1")
 public class HealthCheckController {
 
 

--- a/src/main/java/com/progmong/api/pet/controller/UserPetController.java
+++ b/src/main/java/com/progmong/api/pet/controller/UserPetController.java
@@ -51,6 +51,9 @@ public class UserPetController {
             @AuthenticationPrincipal SecurityUser user) {
         Long userId = user.getId();
         UserPetFullDto dto = userPetService.getUserPetFullInfo(userId);
+        if (dto.getUserPetId() == null) {
+            return ApiResponse.success(SuccessStatus.PET_INFO_NOT_FOUND,dto);
+        }
         return ApiResponse.success(SuccessStatus.PET_INFO_LOADED, dto);
     }
 }

--- a/src/main/java/com/progmong/api/pet/service/UserPetService.java
+++ b/src/main/java/com/progmong/api/pet/service/UserPetService.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -51,8 +53,10 @@ public class UserPetService {
     }
 
     public UserPetFullDto getUserPetFullInfo(Long userId) {
-        UserPet userPet = userPetRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저의 펫 정보가 없습니다."));
-        return new UserPetFullDto(userPet);
+        Optional<UserPet> userPet = userPetRepository.findByUserId(userId);
+                if (userPet.isEmpty()) {
+                    return new UserPetFullDto(); // 빈 DTO 반환
+                }
+        return new UserPetFullDto(userPet.get());
     }
 }

--- a/src/main/java/com/progmong/api/user/Controller/UserController.java
+++ b/src/main/java/com/progmong/api/user/Controller/UserController.java
@@ -5,12 +5,14 @@ import com.progmong.api.user.service.EmailService;
 import com.progmong.api.user.service.UserService;
 import com.progmong.common.config.security.SecurityUser;
 import com.progmong.common.exception.BadRequestException;
+import com.progmong.common.exception.UnauthorizedException;
 import com.progmong.common.response.ApiResponse;
 import com.progmong.common.response.ErrorStatus;
 import com.progmong.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -144,5 +146,27 @@ public class UserController {
         UserInfoResponseDto userInfo = userService.getUserInfo(securityUser.getId());
         return ApiResponse.success(SuccessStatus.GET_USER_INFO_SUCCESS, userInfo);
     }
+
+    @PostMapping("/reissue")
+    @Operation(
+            summary = "Access Token 재발급 API",
+            description = "Refresh Token을 이용해 Access Token을 재발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Access Token 재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Refresh Token이 유효하지 않습니다.")
+    })
+    public ResponseEntity<ApiResponse<UserAccessTokenResponseDto>> reissueAccessToken(
+            HttpServletRequest request) {
+
+        String refreshTokenHeader = request.getHeader("Authorization_refresh");
+        if (refreshTokenHeader == null ) {
+            throw new UnauthorizedException("Refresh Token이 없습니다.");
+        }
+
+        UserAccessTokenResponseDto responseDto = userService.reissueAccessTokenByRefreshToken(refreshTokenHeader);
+        return ApiResponse.success(SuccessStatus.OK, responseDto);
+    }
+
 
 }

--- a/src/main/java/com/progmong/api/user/dto/UserAccessTokenResponseDto.java
+++ b/src/main/java/com/progmong/api/user/dto/UserAccessTokenResponseDto.java
@@ -1,0 +1,12 @@
+package com.progmong.api.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserAccessTokenResponseDto {
+    private String accessToken;
+
+
+}

--- a/src/main/java/com/progmong/api/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/progmong/api/user/dto/UserLoginResponseDto.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserLoginResponseDto {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/progmong/api/user/jwt/filter/ErrorResponse.java
+++ b/src/main/java/com/progmong/api/user/jwt/filter/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.progmong.api.user.jwt.filter;
+
+public class ErrorResponse {
+    private String code;
+    private String message;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    // Getters and Setters
+}

--- a/src/main/java/com/progmong/api/user/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/progmong/api/user/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,9 +1,11 @@
 package com.progmong.api.user.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.progmong.api.user.entity.User;
 import com.progmong.api.user.jwt.service.JwtService;
 import com.progmong.api.user.repository.UserRepository;
 import com.progmong.common.config.security.SecurityUser;
+import com.progmong.common.exception.UnauthorizedException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +19,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -26,10 +30,13 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Value("${jwt.access.header}")
     private String accessTokenHeader;
 
+    @Value("${jwt.refresh.header}")
+    private String refreshTokenHeader;
+
     private final JwtService jwtService;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper; // ObjectMapper 주입 필요
 
-    // Swagger UI 등의 특정 URI를 필터 적용 대상에서 제외할 때 사용
     private static final String[] SWAGGER_URIS = {
             "/swagger-ui",
             "/v3/api-docs",
@@ -39,8 +46,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String requestURI = request.getRequestURI();
-        for(String uri : SWAGGER_URIS) {
-            if(requestURI.startsWith(uri)) {
+        for (String uri : SWAGGER_URIS) {
+            if (requestURI.startsWith(uri)) {
                 return true;
             }
         }
@@ -51,31 +58,78 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        //요청 헤더에서 Access Token을 추출하고, 유효하다면 해당 회원 정보를 SecurityContext에 설정
-        Optional<String> accessToken = extractToken(request, accessTokenHeader)
-                .filter(jwtService::isTokenValid);
+        try {
+            // 1. Access Token 검증
+            Optional<String> accessToken = extractToken(request, accessTokenHeader);
 
-        accessToken.ifPresent(token ->
-                jwtService.extractUserId(token)
-                        .ifPresent(id->
-                                userRepository.findById(Long.valueOf(id))
-                                        .ifPresent(this::setAuthentication)
-                        )
-        );
+            if (accessToken.isPresent()) {
+                boolean valid = jwtService.isTokenValid(accessToken.get()); // 여기서 exception 발생 가능
+                if (valid) {
+                    jwtService.extractUserId(accessToken.get())
+                            .flatMap(id -> findAndAuthenticateUser(id, "AccessToken"))
+                            .ifPresentOrElse(
+                                    this::setAuthentication,
+                                    () -> log.warn("AccessToken 유효하지만 사용자 정보 없음")
+                            );
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            }
 
-        filterChain.doFilter(request, response);
+            // 2. Refresh Token 검증
+            Optional<String> refreshToken = extractRefreshToken(request, refreshTokenHeader);
+            if (refreshToken.isPresent()) {
+                boolean valid = jwtService.isRefreshTokenValid(refreshToken.get()); // exception 발생 가능
+                if (valid) {
+                    jwtService.extractUserIdByRefresh(refreshToken.get())
+                            .flatMap(id -> findAndAuthenticateUser(id, "RefreshToken"))
+                            .ifPresentOrElse(
+                                    this::setAuthentication,
+                                    () -> log.warn("RefreshToken 유효하지만 사용자 정보 없음")
+                            );
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            }
+
+            // 둘 다 없거나 유효하지 않음 → 다음 필터로 그냥 넘김
+            filterChain.doFilter(request, response);
+
+        } catch (UnauthorizedException e) {
+            sendErrorResponse(response, "UNAUTHORIZED", e.getMessage());
+        } catch (Exception e) {
+            sendErrorResponse(response, "UNKNOWN_ERROR", "알 수 없는 오류가 발생했습니다.");
+        }
     }
 
-    // 요청 헤더에서 "Bearer " 로 시작하는 토큰 부분만 잘라서 반환
+
+    private Optional<User> findAndAuthenticateUser(String id, String tokenType) {
+        try {
+            Optional<User> user = userRepository.findById(Long.valueOf(id));
+            user.ifPresent(u -> log.debug("{} 인증 성공: {}", tokenType, u.getEmail()));
+            return user;
+        } catch (NumberFormatException e) {
+            log.error("{}로부터 잘못된 사용자 ID: {}", tokenType, id);
+            return Optional.empty();
+        }
+    }
+
     private Optional<String> extractToken(HttpServletRequest request, String headerName) {
         String bearerToken = request.getHeader(headerName);
-        if(bearerToken != null && bearerToken.startsWith("Bearer ")) {
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return Optional.of(bearerToken.substring(7));
         }
         return Optional.empty();
     }
 
-    // 인증 정보를 만들어서 SecurityContext에 저장
+    private Optional<String> extractRefreshToken(HttpServletRequest request, String headerName) {
+        String refreshToken = request.getHeader(headerName);
+        if (refreshToken != null) {
+            return Optional.of(refreshToken);
+        }
+        return Optional.empty();
+    }
+
     private void setAuthentication(User user) {
         SecurityUser securityUser = SecurityUser.builder()
                 .id(user.getId())
@@ -93,4 +147,16 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
+    private void sendErrorResponse(HttpServletResponse response, String errorCode, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("error", errorCode);
+        errorResponse.put("message", message);
+        errorResponse.put("status", 401);
+        errorResponse.put("timestamp", System.currentTimeMillis());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
 }

--- a/src/main/java/com/progmong/api/user/jwt/service/JwtService.java
+++ b/src/main/java/com/progmong/api/user/jwt/service/JwtService.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.progmong.api.user.repository.UserRepository;
+import com.progmong.common.exception.UnauthorizedException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -24,8 +25,14 @@ public class JwtService {
     @Value("${jwt.secretKey}")
     private String secretKey;
 
+    @Value("${jwt.refresh.secretKey}")
+    private String refreshSecretKey;
+
     @Value("${jwt.access.expiration}")
     private Long accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
 
     private final UserRepository userRepository;
 
@@ -38,22 +45,50 @@ public class JwtService {
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
-    // 토큰 유효성 검사
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(refreshSecretKey));
+    }
+
+    // Access Token 유효성 검사
     public boolean isTokenValid(String token) {
+        if (token == null || token.isBlank()) {
+            throw new UnauthorizedException("토큰이 제공되지 않았습니다.");
+        }
+
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (TokenExpiredException e) {
-            log.error("토큰이 만료되었습니다: {}", e.getMessage());
-            return false;
+            throw new UnauthorizedException("토큰이 만료되었습니다.");
         } catch (SignatureVerificationException e) {
-            log.error("토큰 서명 검증 실패: {}", e.getMessage());
-            return false;
+            throw new UnauthorizedException("토큰 서명 검증에 실패했습니다.");
         } catch (Exception e) {
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
-            return false;
+            throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }
     }
+
+    // Refresh Token 유효성 검사
+    public boolean isRefreshTokenValid(String token) {
+        if (token == null || token.isBlank()) {
+            throw new UnauthorizedException("Refresh Token이 제공되지 않았습니다.");
+        }
+
+        try {
+            JWT.require(Algorithm.HMAC512(refreshSecretKey)).build().verify(token);
+            return true;
+        } catch (TokenExpiredException e) {
+            throw new UnauthorizedException("Refresh Token이 만료되었습니다.");
+        } catch (SignatureVerificationException e) {
+            throw new UnauthorizedException("Refresh Token 서명 검증에 실패했습니다.");
+        } catch (Exception e) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token입니다.");
+        }
+    }
+
 
     // 토큰에서 회원 ID 추출
     public Optional<String> extractUserId(String accessToken) {
@@ -61,6 +96,20 @@ public class JwtService {
             String sub = JWT.require(Algorithm.HMAC512(secretKey))
                     .build()
                     .verify(accessToken)
+                    .getClaim("sub")
+                    .asString();
+            return Optional.ofNullable(sub);
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    public Optional<String> extractUserIdByRefresh(String refreshToken) {
+        try {
+            String sub = JWT.require(Algorithm.HMAC512(refreshSecretKey))
+                    .build()
+                    .verify(refreshToken)
                     .getClaim("sub")
                     .asString();
             return Optional.ofNullable(sub);
@@ -84,4 +133,6 @@ public class JwtService {
             return Optional.empty();
         }
     }
+
+
 }

--- a/src/main/java/com/progmong/api/user/service/UserService.java
+++ b/src/main/java/com/progmong/api/user/service/UserService.java
@@ -75,8 +75,11 @@ public class UserService {
 
         // JWT 토큰 생성 (Access)
         String accessToken = jwtService.createAccessToken(user.getId());
+        // JWT 토큰 생성 (Refresh)
+        String refreshToken = jwtService.createRefreshToken(user.getId());
 
-        return new UserLoginResponseDto(accessToken);
+
+        return new UserLoginResponseDto(accessToken, refreshToken);
     }
 
     // 비밀번호 초기화
@@ -111,4 +114,23 @@ public class UserService {
 
         return new UserInfoResponseDto(user.getId(), user.getBojId(), user.getEmail(),user.getNickname() );
     }
+
+    // Access Token 재발급
+
+    public UserAccessTokenResponseDto reissueAccessTokenByRefreshToken(String refreshToken) {
+        if (!jwtService.isRefreshTokenValid(refreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 유효하지 않습니다.");
+        }
+
+        String userId = jwtService.extractUserIdByRefresh(refreshToken)
+                .orElseThrow(() -> new UnauthorizedException("토큰에서 사용자 정보를 추출할 수 없습니다."));
+
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new NotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtService.createAccessToken(user.getId());
+
+        return new UserAccessTokenResponseDto(newAccessToken);
+    }
+
 }

--- a/src/main/java/com/progmong/common/config/jwt/JwtConfig.java
+++ b/src/main/java/com/progmong/common/config/jwt/JwtConfig.java
@@ -1,5 +1,6 @@
 package com.progmong.common.config.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.progmong.api.user.jwt.filter.JwtAuthenticationProcessingFilter;
 import com.progmong.api.user.jwt.service.JwtService;
 import com.progmong.api.user.repository.UserRepository;
@@ -13,9 +14,9 @@ public class JwtConfig {
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
-    
+    private final ObjectMapper objectMapper;
     @Bean
     public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
-        return new JwtAuthenticationProcessingFilter(jwtService, userRepository);
+        return new JwtAuthenticationProcessingFilter(jwtService, userRepository, objectMapper);
     }
 }

--- a/src/main/java/com/progmong/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/progmong/common/config/security/SecurityConfig.java
@@ -46,10 +46,10 @@ public class SecurityConfig {
                     ));
                     config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH","DELETE", "OPTIONS"));
                     config.setAllowCredentials(true);
-                    config.setAllowedHeaders(Arrays.asList("Authorization", "Authorization-Refresh","Content-Type", "X-Requested-With", "Accept", "Origin"));
+                    config.setAllowedHeaders(Arrays.asList("Authorization", "Authorization_refresh","Content-Type", "X-Requested-With", "Accept", "Origin"));
                     config.setMaxAge(3600L);
                     config.addExposedHeader("Authorization");
-                    config.addExposedHeader("Authorization-Refresh");
+                    config.addExposedHeader("Authorization_refresh");
                     return config;
                 }))
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))

--- a/src/main/java/com/progmong/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/progmong/common/config/swagger/SwaggerConfig.java
@@ -16,19 +16,27 @@ public class SwaggerConfig {
     @Value("${jwt.access.header}")
     private String accessTokenHeader;
 
+    @Value("${jwt.refresh.header}")
+    private String refreshTokenHeader;
+
     @Bean
     public OpenAPI openAPI() {
         SecurityScheme accessTokenScheme = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
+                .type(SecurityScheme.Type.APIKEY)   // 여기 중요!
                 .in(SecurityScheme.In.HEADER)
-                .name(accessTokenHeader);
+                .name(accessTokenHeader); // 일반적으로 "Authorization"
 
         SecurityRequirement accessTokenRequirement = new SecurityRequirement()
                 .addList(accessTokenHeader);
 
-        // 서버(서버 URL) 정보
+        SecurityScheme refreshTokenScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(refreshTokenHeader); // 예: "Refresh"
+
+        SecurityRequirement refreshTokenRequirement = new SecurityRequirement()
+                .addList(refreshTokenHeader);
+
         Server server = new Server();
         server.setUrl("http://localhost:8100");
 
@@ -38,8 +46,10 @@ public class SwaggerConfig {
                         .description("프로그몽 REST API Document")
                         .version("1.0.0"))
                 .components(new Components()
-                        .addSecuritySchemes(accessTokenHeader, accessTokenScheme))
+                        .addSecuritySchemes(accessTokenHeader, accessTokenScheme)
+                        .addSecuritySchemes(refreshTokenHeader, refreshTokenScheme))
                 .addServersItem(server)
-                .addSecurityItem(accessTokenRequirement);
+                .addSecurityItem(accessTokenRequirement)
+                .addSecurityItem(refreshTokenRequirement);
     }
 }

--- a/src/main/java/com/progmong/common/response/SuccessStatus.java
+++ b/src/main/java/com/progmong/common/response/SuccessStatus.java
@@ -22,6 +22,7 @@ public enum SuccessStatus {
     SEND_UPDATE_USER_PASSWORD(HttpStatus.OK, "비밀번호 변경 성공"),
     GET_USER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
     PET_INFO_LOADED(HttpStatus.OK, "사용자 펫 정보 조회 성공"),
+    PET_INFO_NOT_FOUND(HttpStatus.OK, "사용자 펫 정보가 없습니다."),
 
     PET_STATUS_UPDATED(HttpStatus.OK, "펫 상태가 변경되었습니다."),
     PET_REGISTERED(HttpStatus.CREATED, "펫 등록이 완료되었습니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
리프레시 토큰 추가 및 유저 펫 정보조회 수정

- close #36 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
액세스 토큰이 만료되었을 때, 리프레시 토큰을 사용해 새로운 액세스 토큰을 발급받아 사용자 인증을 유지

현재 유저 펫이 없을 때 500 에러 -> 펫이 없는 상황인지, 진짜 서버 오류인지 구분 할 수 없기 때문에 프론트에서 펫이 없는 경우를 잡을 수 없으므로 다음과 같이 수정
펫이 없을때 200 OK + null 응답을 보냄 -> 프론트는 그 응답값이 null인지 판단
